### PR TITLE
Do not stop on download errors if the video does not exist.

### DIFF
--- a/contentpacks/khanacademy.py
+++ b/contentpacks/khanacademy.py
@@ -171,6 +171,8 @@ def retrieve_subtitles(videos: list, lang=EN_LANG_CODE, force=False, threads=NUM
             "writesubtitles": True,
             "skip_download": True,
             "subtitleslangs": [lang],
+            "ignoreerrors": True,
+
         }
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
             ydl.download(['http://www.youtube.com/watch?v=%s' % youtube_id])


### PR DESCRIPTION
## Summary
If the video does not exist ignore error and continue downloading the subtitles. 
Sample output below:
```
INFO:root:trying to download subtitle for UjU0tpulIQ8
[youtube] UjU0tpulIQ8: Downloading webpage
[youtube] UjU0tpulIQ8: Downloading video info webpage
ERROR: UjU0tpulIQ8: YouTube said: This video does not exist.
INFO:root:No available subtitle for (UjU0tpulIQ8)
INFO:root:trying to download subtitle for Xcrco59p40o
[youtube] Xcrco59p40o: Downloading webpage
[youtube] Xcrco59p40o: Downloading video info webpage
[youtube] Xcrco59p40o: Extracting video information
[youtube] Xcrco59p40o: Downloading MPD manifest
[info] Writing video subtitles to: /Users/mrpau-eduard/content-pack-maker/contentpacks/build/subtitles/en/Xcrco59p40o.en.vtt
INFO:root:Rename /Users/mrpau-eduard/content-pack-maker/contentpacks/build/subtitles/en/Xcrco59p40o.en.vtt -> /Users/mrpau-eduard/content-pack-maker/contentpacks/build/subtitles/en/Xcrco59p40o.vtt
```

## Issues addressed
#66 
